### PR TITLE
Added playlist icon to error torrents

### DIFF
--- a/templates/home/part_ui/error_torrents.html
+++ b/templates/home/part_ui/error_torrents.html
@@ -17,6 +17,7 @@
                     {% if t.torrent_done == 1 %}
                         <a href="{% url 'download.views.download_zip' t.what_torrent_id %}"><i class="fa fa-download" style="margin:2px"></i></a>
                         <a href="javascript: playWhat({{ t.what_torrent_id }}); void(0);"><i class="fa fa-play-circle" style="margin:2px"></i></a>
+                        <a href="{% url 'download.views.download_pls' t.playlist_name %}?username={{ request.user.username }}&token={{ token }}"><i class="fa fa-list-ol" style="margin:2px"></i></a>
                         <a href="{{ t.what_torrent_id|what_cd_torrent_link }}" target="_blank"><i class="fa fa-external-link" style="margin:2px"></i></a>
                     {% else %}
                         downloading


### PR DESCRIPTION
Torrents with errors retain play and download, why not playlist?