### PR TITLE
Feature/torrent delete improvements

### DIFF
--- a/download/views.py
+++ b/download/views.py
@@ -5,7 +5,7 @@ import zipfile
 
 from django.contrib.auth.decorators import login_required, permission_required
 from django.http.response import HttpResponse
-from django.shortcuts import render
+from django.shortcuts import render, redirect
 from django.template.defaultfilters import filesizeformat
 
 from WhatManager2.utils import build_url, get_user_token, auth_username_token

--- a/download/views.py
+++ b/download/views.py
@@ -144,7 +144,7 @@ def delete_torrent(request, what_id):
     WhatTorrent.objects.get(info_hash=t_torrent.info_hash).delete()
     t_torrent.instance.client.remove_torrent(t_torrent.info_hash)
     try:
-        shutil.rmtree("/mnt/redmanager/testing", onerror=attemptFixPermissions)
+        shutil.rmtree(path, onerror=attemptFixPermissions)
         return redirect('home.views.torrents')
     except OSError as e:
         if e.errno == errno.EPERM: # Operation not permitted

--- a/download/views.py
+++ b/download/views.py
@@ -8,7 +8,7 @@ from django.http.response import HttpResponse
 from django.shortcuts import render, redirect
 from django.template.defaultfilters import filesizeformat
 
-from WhatManager2.utils import build_url, get_user_token, auth_username_token
+from WhatManager2.utils import build_url, get_user_token, auth_username_token, wm_str
 from bibliotik.models import BibliotikTransTorrent
 from home.models import TransTorrent, WhatTorrent, ReplicaSet, LogEntry
 from player.player_utils import get_playlist_files
@@ -139,7 +139,7 @@ def delete_torrent(request, what_id):
     if not t_torrent:
         return HttpResponse('Could not find that torrent.')
 
-    path = t_torrent.path
+    path = wm_str(t_torrent.path) # Save this because t_torrent won't exist before rmtree is called
     WhatTorrent.objects.get(info_hash=t_torrent.info_hash).delete()
     t_torrent.instance.client.remove_torrent(t_torrent.info_hash)
     shutil.rmtree(path)

--- a/templates/home/part_ui/downloading.html
+++ b/templates/home/part_ui/downloading.html
@@ -3,7 +3,7 @@
 <table class="table table-bordered table-striped table-hover">
     <thead>
     <tr>
-        <th class="col-actions">Manage</th>
+        <th class="col-actions" style="width: 120px">Manage</th>
         <th style="width: 160px;">Progress</th>
         <th>Name</th>
     </tr>
@@ -15,6 +15,9 @@
             <td>
                 {% if t|type_name == 'TransTorrent' %}
                     <a href="{{ t.what_torrent_id|what_cd_torrent_link }}" target="_blank"><i class="fa fa-external-link" style="margin:2px"></i></a>
+                    <a href="{% url 'download.views.delete_torrent' t.what_torrent_id %}" onclick="return confirm('Are you sure you want to delete this torrent and all its data?')">
+                        <i class="fa fa-trash-o" style="margin:2px; color:red"></i>
+                    </a>
                 {% elif t|type_name == 'BibliotikTransTorrent' %}
                     <a href="{{ t.bibliotik_torrent_id|bibliotik_torrent_link }}" target="_blank"><i class="fa fa-external-link" style="margin:2px"></i></a>
                 {% endif %}

--- a/templates/home/part_ui/error_torrents.html
+++ b/templates/home/part_ui/error_torrents.html
@@ -3,7 +3,7 @@
 <table class="table table-bordered table-hover" data-torrent-count="{{ torrents|length }}">
     <thead>
     <tr>
-        <th class="col-actions">Manage</th>
+        <th class="col-actions" style="width: 120px">Manage</th>
         <th>Name</th>
         <th>Error</th>
     </tr>

--- a/templates/home/part_ui/error_torrents.html
+++ b/templates/home/part_ui/error_torrents.html
@@ -17,13 +17,13 @@
                     {% if t.torrent_done == 1 %}
                         <a href="{% url 'download.views.download_zip' t.what_torrent_id %}"><i class="fa fa-download" style="margin:2px"></i></a>
                         <a href="javascript: playWhat({{ t.what_torrent_id }}); void(0);"><i class="fa fa-play-circle" style="margin:2px"></i></a>
-                        <a href="{% url 'download.views.delete_torrent' t.what_torrent_id %}" onclick="return confirm('Are you sure you want to delete this torrent and all its data?')">
-                            <i class="fa fa-trash-o" style="margin:2px; color:red"></i>
-                        </a>
                     {% else %}
                         downloading
                     {% endif %}
-					<a href="{{ t.what_torrent_id|what_cd_torrent_link }}" target="_blank"><i class="fa fa-external-link" style="margin:2px"></i></a>
+                    <a href="{{ t.what_torrent_id|what_cd_torrent_link }}" target="_blank"><i class="fa fa-external-link" style="margin:2px"></i></a>
+                    <a href="{% url 'download.views.delete_torrent' t.what_torrent_id %}" onclick="return confirm('Are you sure you want to delete this torrent and all its data?')">
+                        <i class="fa fa-trash-o" style="margin:2px; color:red"></i>
+                    </a>
                 {% elif t|type_name == 'BibliotikTransTorrent' %}
                     <a href="{{ t.bibliotik_torrent_id|bibliotik_torrent_link }}" target="_blank"><i class="fa fa-external-link" style="margin:2px"></i></a>
                     {% if t.torrent_done == 1 %}

--- a/templates/home/part_ui/search_torrents.html
+++ b/templates/home/part_ui/search_torrents.html
@@ -25,7 +25,7 @@
                         <a href="javascript: playWhat({{ t.id }}); void(0);"><i class="fa fa-play-circle" style="margin:2px"></i></a>
                         <a href="{% url 'download.views.download_pls' t.playlist_name %}?username={{ request.user.username }}&token={{ token }}"><i class="fa fa-list-ol" style="margin:2px"></i></a>
                         {% else %}
-                            downloading
+                            downloading<br>
                         {% endif %}
                         <a href="{{ t.id|what_cd_torrent_link }}" target="_blank"><i class="fa fa-external-link" style="margin:2px"></i></a>
                         <a href="{% url 'download.views.delete_torrent' t.id %}" onclick="return confirm('Are you sure you want to delete this torrent and all its data?')">

--- a/templates/home/part_ui/search_torrents.html
+++ b/templates/home/part_ui/search_torrents.html
@@ -3,7 +3,7 @@
 <table class="table table-bordered table-striped table-hover" data-torrent-count="{{ torrents|length }}">
     <thead>
     <tr>
-        <th class="col-actions">What</th>
+        <th class="col-actions" style="width: 120px">Manage</th>
         <th>Name</th>
     </tr>
     </thead>
@@ -20,14 +20,17 @@
             <tr>
                 {% if t|type_name == 'WhatTorrent' %}
                     <td>
-                        <a href="{{ t.id|what_cd_torrent_link }}" target="_blank">w: {{ t.id }}</a>
                         {% if t.transtorrent_set.all.0.torrent_done == 1 %}
-                            <a href="{% url 'download.views.download_pls' t.playlist_name %}?username={{ request.user.username }}&token={{ token }}">pls</a>
-                            <a href="{% url 'download.views.download_zip' t.id %}">download</a>
-                            <a href="javascript: playWhat({{ t.id }}); void(0);">play</a>
+                        <a href="{% url 'download.views.download_zip' t.id %}"><i class="fa fa-download" style="margin:2px"></i></a>
+                        <a href="javascript: playWhat({{ t.id }}); void(0);"><i class="fa fa-play-circle" style="margin:2px"></i></a>
+                        <a href="{% url 'download.views.download_pls' t.playlist_name %}?username={{ request.user.username }}&token={{ token }}"><i class="fa fa-list-ol" style="margin:2px"></i></a>
                         {% else %}
                             downloading
                         {% endif %}
+                        <a href="{{ t.id|what_cd_torrent_link }}" target="_blank"><i class="fa fa-external-link" style="margin:2px"></i></a>
+                        <a href="{% url 'download.views.delete_torrent' t.id %}" onclick="return confirm('Are you sure you want to delete this torrent and all its data?')">
+                            <i class="fa fa-trash-o" style="margin:2px; color:red"></i>
+                        </a>
                     </td>
 
                     <td>


### PR DESCRIPTION
- Now will attempt to change permissions on read-only files
- When permissions cannot be changed, it gracefully presents an error and the relevant path for manual deletion by the user
- Trash icons are now available for partially downloaded torrents and search result torrents
- Deletion of folders and files with unicode characters is now supported
- Redirect after deletion is now fixed